### PR TITLE
Fix searcher so that it moves ahead after each match, enabling it to …

### DIFF
--- a/streamexpect.py
+++ b/streamexpect.py
@@ -641,6 +641,7 @@ class BytesExpecter(Expecter, ExpectBytesMixin, ExpectRegexMixin):
         super(BytesExpecter, self).__init__(stream_adapter, input_callback,
                                             window, close_adapter)
         self._history = six.binary_type()
+        self._start = 0
 
     def expect(self, searcher, timeout=3):
         """Wait for input matching *searcher*
@@ -657,17 +658,23 @@ class BytesExpecter(Expecter, ExpectBytesMixin, ExpectRegexMixin):
         """
         timeout = float(timeout)
         end = time.time() + timeout
-        match = searcher.search(self._history)
+        match = searcher.search(self._history[self._start:])
         while not match:
             # poll() will raise ExpectTimeout if time is exceeded
             incoming = self._stream_adapter.poll(end - time.time())
             self.input_callback(incoming)
             self._history += incoming
-            match = searcher.search(self._history)
+            match = searcher.search(self._history[self._start:])
+            trimlength = len(self._history) - self._window
+            if trimlength > 0:
+                self._start -= trimlength
+                self._history = self._history[trimlength:]
 
         if match:
-            self._history = self._history[(match.end+1):]
-        self._history = self._history[(self._window * (-1)):]
+            self._start += match.end
+        if (self._start < 0):
+            self._start = 0
+
         return match
 
 
@@ -687,6 +694,7 @@ class TextExpecter(Expecter, ExpectTextMixin, ExpectRegexMixin):
         super(TextExpecter, self).__init__(stream_adapter, input_callback,
                                            window, close_adapter)
         self._history = six.text_type()
+        self._start = 0
 
     def expect(self, searcher, timeout=3):
         """Wait for input matching *searcher*.
@@ -703,14 +711,23 @@ class TextExpecter(Expecter, ExpectTextMixin, ExpectRegexMixin):
         """
         timeout = float(timeout)
         end = time.time() + timeout
-        match = None
+        match = searcher.search(self._history[self._start:])
         while not match:
             # poll() will raise ExpectTimeout if time is exceeded
             incoming = self._stream_adapter.poll(end - time.time())
             self.input_callback(incoming)
             self._history += incoming
-            match = searcher.search(self._history)
-            self._history = self._history[(self._window * (-1)):]
+            match = searcher.search(self._history[self._start:])
+            trimlength = len(self._history) - self._window
+            if trimlength > 0:
+                self._start -= trimlength
+                self._history = self._history[trimlength:]
+
+        if match:
+            self._start += match.end
+        if (self._start < 0):
+            self._start = 0
+
         return match
 
 

--- a/streamexpect.py
+++ b/streamexpect.py
@@ -657,14 +657,17 @@ class BytesExpecter(Expecter, ExpectBytesMixin, ExpectRegexMixin):
         """
         timeout = float(timeout)
         end = time.time() + timeout
-        match = None
+        match = searcher.search(self._history)
         while not match:
             # poll() will raise ExpectTimeout if time is exceeded
             incoming = self._stream_adapter.poll(end - time.time())
             self.input_callback(incoming)
             self._history += incoming
             match = searcher.search(self._history)
-            self._history = self._history[(self._window * (-1)):]
+
+        if match:
+            self._history = self._history[(match.end+1):]
+        self._history = self._history[(self._window * (-1)):]
         return match
 
 

--- a/streamexpect.py
+++ b/streamexpect.py
@@ -670,8 +670,7 @@ class BytesExpecter(Expecter, ExpectBytesMixin, ExpectRegexMixin):
                 self._start -= trimlength
                 self._history = self._history[trimlength:]
 
-        if match:
-            self._start += match.end
+        self._start += match.end
         if (self._start < 0):
             self._start = 0
 
@@ -723,8 +722,7 @@ class TextExpecter(Expecter, ExpectTextMixin, ExpectRegexMixin):
                 self._start -= trimlength
                 self._history = self._history[trimlength:]
 
-        if match:
-            self._start += match.end
+        self._start += match.end
         if (self._start < 0):
             self._start = 0
 

--- a/test/test_streamexpect.py
+++ b/test/test_streamexpect.py
@@ -498,7 +498,7 @@ class TestWrapper(unittest.TestCase):
             source.close()
             drain.close()
 
-    def test_expect_text_twice_on_one_buffer(self):
+    def test_expect_text_twice(self):
         stream = PiecewiseStream(u('tau iota mu'), max_chunk=3)
         wrapper = streamexpect.wrap(stream, unicode=True)
         match = wrapper.expect_text(u('iota'))
@@ -508,6 +508,16 @@ class TestWrapper(unittest.TestCase):
         self.assertTrue(match is not None)
         self.assertEqual(u('mu'), match.match)
 
+    def test_expect_text_twice_with_small_window(self):
+        stream = PiecewiseStream(u('tau iota mu'), max_chunk=3)
+        wrapper = streamexpect.wrap(stream, unicode=True, window=8)
+        match = wrapper.expect_text(u('iota'))
+        self.assertTrue(match is not None)
+        self.assertEqual(u('iota'), match.match)
+        match = wrapper.expect_text(u('mu'))
+        self.assertTrue(match is not None)
+        self.assertEqual(u('mu'), match.match)
+        
     def test_expect_unicode_regex(self):
         stream = PiecewiseStream(u('pi epsilon mu'), max_chunk=3)
         wrapper = streamexpect.wrap(stream, unicode=True)

--- a/test/test_streamexpect.py
+++ b/test/test_streamexpect.py
@@ -482,6 +482,22 @@ class TestWrapper(unittest.TestCase):
             source.close()
             drain.close()
 
+    def test_expect_bytes_twice_on_split_buffer_with_small_window(self):
+        source, drain = socket.socketpair()
+        try:
+            wrapper = streamexpect.wrap(drain, unicode=False, window=8)
+            source.sendall(b'tau iota m')
+            match = wrapper.expect_bytes(b'iota')
+            self.assertTrue(match is not None)
+            self.assertEqual(b'iota', match.match)
+            source.sendall(b'u tau iota')
+            match = wrapper.expect_bytes(b'mu')
+            self.assertTrue(match is not None)
+            self.assertEqual(b'mu', match.match)
+        finally:
+            source.close()
+            drain.close()
+
     def test_expect_text_twice_on_one_buffer(self):
         stream = PiecewiseStream(u('tau iota mu'), max_chunk=3)
         wrapper = streamexpect.wrap(stream, unicode=True)

--- a/test/test_streamexpect.py
+++ b/test/test_streamexpect.py
@@ -467,6 +467,31 @@ class TestWrapper(unittest.TestCase):
         self.assertTrue(match is not None)
         self.assertEqual(u('iota'), match.match)
 
+    def test_expect_bytes_twice_on_one_buffer(self):
+        source, drain = socket.socketpair()
+        try:
+            wrapper = streamexpect.wrap(drain, unicode=False)
+            source.sendall(b'tau iota mu')
+            match = wrapper.expect_bytes(b'iota')
+            self.assertTrue(match is not None)
+            self.assertEqual(b'iota', match.match)
+            match = wrapper.expect_bytes(b'mu')
+            self.assertTrue(match is not None)
+            self.assertEqual(b'mu', match.match)
+        finally:
+            source.close()
+            drain.close()
+
+    def test_expect_text_twice_on_one_buffer(self):
+        stream = PiecewiseStream(u('tau iota mu'), max_chunk=3)
+        wrapper = streamexpect.wrap(stream, unicode=True)
+        match = wrapper.expect_text(u('iota'))
+        self.assertTrue(match is not None)
+        self.assertEqual(u('iota'), match.match)
+        match = wrapper.expect_text(u('mu'))
+        self.assertTrue(match is not None)
+        self.assertEqual(u('mu'), match.match)
+
     def test_expect_unicode_regex(self):
         stream = PiecewiseStream(u('pi epsilon mu'), max_chunk=3)
         wrapper = streamexpect.wrap(stream, unicode=True)

--- a/test/test_streamexpect.py
+++ b/test/test_streamexpect.py
@@ -509,7 +509,7 @@ class TestWrapper(unittest.TestCase):
         self.assertEqual(u('mu'), match.match)
 
     def test_expect_text_twice_with_small_window(self):
-        stream = PiecewiseStream(u('tau iota mu'), max_chunk=3)
+        stream = PiecewiseStream(u('tau iota epsilon mu'), max_chunk=20)
         wrapper = streamexpect.wrap(stream, unicode=True, window=8)
         match = wrapper.expect_text(u('iota'))
         self.assertTrue(match is not None)


### PR DESCRIPTION
…find successive strings from the same poll result.

I had issues finding strings already read from the underlying stream because each time the expect-method is called, it will only search in data read from that point in time.
