### PR TITLE
Add support for python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=py35
+  - TOX_ENV=py37
+  - TOX_ENV=py39
+  - TOX_ENV=py310
   - TOX_ENV=pypy
   - TOX_ENV=pypy3
   - TOX_ENV=coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[nosetests]
-tests = test
-verbosity = 1
-detailed-errors = 1
-with-coverage = 1
-cover-package = streamexpect
-cover-branches = 1
-with-doctest = 1
-
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -36,20 +36,14 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries',
     ],
     py_modules=['streamexpect'],
     install_requires=[
         'six>=1.10'
     ],
-    test_suite='nose.collector',
-    tests_require=[
-        'testfixtures>=4.1',
-    ],
-    setup_requires=[
-        'nose>=1.3',
-        'coverage>=4.0',
-        'setuptools-markdown>=0.1',
-    ],
-    long_description_markdown_filename='README.md',
+    long_description=open("README.md", "r").read(),
+    long_description_content_type='text/markdown'
 )

--- a/streamexpect.py
+++ b/streamexpect.py
@@ -5,7 +5,11 @@
 #
 # Copyright (c) 2015 Digi International Inc. All Rights Reserved.
 
-import collections
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # For backward compatibility with Python2
+    from collections import Sequence
 import re
 import six
 import socket
@@ -258,7 +262,7 @@ class RegexSearcher(Searcher):
 
 def _flatten(n):
     """Recursively flatten a mixed sequence of sub-sequences and items"""
-    if isinstance(n, collections.Sequence):
+    if isinstance(n, Sequence):
         for x in n:
             for y in _flatten(x):
                 yield y

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,22 @@
 [tox]
 minversion=2.0
-envlist = py{27,33,34,35}, pypy, pypy3
+envlist = py{27,33,34,35,37,39,310}, pypy, pypy3
 
 [testenv]
-commands = python setup.py nosetests
+deps =
+    pytest
+    testfixtures>=4.1
+commands = pytest
 passenv = TRAVIS*
 
 [testenv:coverage]
 deps =
-    python-coveralls
+    pytest
+    pytest-cov
+    testfixtures>=4.1
+    coveralls
 commands =
-    python setup.py nosetests
+    pytest --cov=streamexpect --cov-branch
     coveralls
 
 [testenv:docs]


### PR DESCRIPTION
Python 3.10 moved the Sequence type under collections.abc, rendering it
incompatible with previous versions. Try to import with this new location
and fallback to previous location to keep backward compatibility with
Python2.

setuptools-mardown is now deprecated, in favor of the
long_description_content_type argument in setup.py. This replacement is
done because the setuptools-mardown library depends on any version of
pypandoc and is now broken with the latest version (1.8) which removed
a function that was used, causing this error:
AttributeError: module 'pypandoc' has no attribute 'convert'

In setup.py, the setup_require key is now deprecated, and has been removed
since build build only needed setuptools-mardown which is no longer needed.
In setup.py, the test_suite and tests_require keys are now deprecated,
in favor of an external testing tool. The tox configuration file now
contain the description of the required test dependencies.

Nose is replaced by pytest in this commit, mainly because I was unable to
run any test using it, and pytest worked as a drop-in replacement.

Regarding the nose to pytest change, I might be simply missing something and can be reverted it if needed.